### PR TITLE
Allow string conversion to deal with unsigned long values

### DIFF
--- a/source/code/providers/support/sqlbinding.h
+++ b/source/code/providers/support/sqlbinding.h
@@ -744,7 +744,7 @@ extern SCXCoreLib::SCXHandle<MySQL_Factory> g_pFactory; //!< Define single globa
 template <typename T> bool ConvertToUnsigned(const std::string& strNum, T& value)
 {
     try {
-        value = SCXCoreLib::StrToUInt( SCXCoreLib::StrFromUTF8(strNum) );
+        value = SCXCoreLib::StrToULong( SCXCoreLib::StrFromUTF8(strNum) );
     }
     catch (SCXCoreLib::SCXNotSupportedException& e)
     {


### PR DESCRIPTION
This allows us to determine the size of databases > 2gb

@Microsoft/ostc-devs 
@agup006 